### PR TITLE
Add sign used in kennokaavio (|)

### DIFF
--- a/app/specialCharacters.js
+++ b/app/specialCharacters.js
@@ -57,7 +57,8 @@ module.exports = [
             { character: '≡', latexCommand: '\\equiv' },
             { character: '≢' }, // \nequiv or \not\equiv
             { character: '∘', latexCommand: '\\circ' },
-            { character: '…', latexCommand: '\\ldots' }
+            { character: '…', latexCommand: '\\ldots' },
+            { character: '|' }
         ]
     },
     {


### PR DESCRIPTION
Not found on Mac laptops.