### PR TITLE
Fix shift+arrow selection in LaTeX field

### DIFF
--- a/app/math-editor.js
+++ b/app/math-editor.js
@@ -57,7 +57,7 @@ function init($outerPlaceholder, focus, baseUrl, updateMathImg) {
 
 
     $latexField
-        .on('keydown', transformLatexKeydown)
+        .on('keypress', transformLatexKeydown)
         .on('input paste', onLatexUpdate)
         .on('focus blur', e => {
             focus.latexField = e.type !== 'blur'


### PR DESCRIPTION
f86f028c6815a01ea368345397abe16db4c39163 broke text selection with shift+arrow in the LaTeX field, this should fix that.