### PR TITLE
Ask for confirmation before closing the demo page

### DIFF
--- a/app/FI.js
+++ b/app/FI.js
@@ -33,7 +33,8 @@ lisätä kuvia.</li></ul>`,
         langLink: '/sv',
         langLabel: 'På svenska',
         answerTitle: 'Vastaus',
-        toggleInstructions: 'Näytä ohjeet'
+        toggleInstructions: 'Näytä ohjeet',
+        confirmExit: 'Haluatko varmasti poistua?'
     },
     annotating: {
         sendFeedback: 'Lähetä palautetta',

--- a/app/SV.js
+++ b/app/SV.js
@@ -28,7 +28,8 @@ module.exports = {
         langLink: '/',
         langLabel: 'Suomeksi',
         answerTitle: 'Svar',
-        toggleInstructions: 'Visa intruktioner'
+        toggleInstructions: 'Visa intruktioner',
+        confirmExit: 'Vill du lämna den här sidan?'
     },
     annotating: {
         sendFeedback: 'Skicka respons',

--- a/proto/student.html.js
+++ b/proto/student.html.js
@@ -54,6 +54,13 @@ module.exports = (obj) => { with(obj) return `
 <script src="/rich-text-editor-bundle.js"></script>
 <script src="/student.js"></script>
 <script>
+    window.onbeforeunload = function(e) {
+        var dialogText = '${confirmExit}'
+        e.returnValue = dialogText
+        return dialogText
+    }
+</script>
+<script>
     (function (i, s, o, g, r, a, m) {
         i['GoogleAnalyticsObject'] = r;
         i[r] = i[r] || function () {


### PR DESCRIPTION
Keeps from accidentally closing the browser window and losing all text written with the demo version of the editor.

Most browsers show a general message instead of the specified text.