### PR TITLE
Fix copy&pasting to use latest copied item from the clipboard items collection

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -9,7 +9,10 @@ const fileTypes = ['image/png', 'image/jpeg']
 
 export function onPaste(e, saver, onValueChanged, limit) {
     const clipboardData = e.originalEvent.clipboardData
-    const file = clipboardData.items && clipboardData.items.length > 0 && clipboardData.items[0].getAsFile()
+    const file =
+        clipboardData.items &&
+        clipboardData.items.length > 0 &&
+        clipboardData.items[clipboardData.items.length - 1].getAsFile()
     if (file) {
         onPasteBlob(e, file, saver, $(e.currentTarget), onValueChanged, limit)
     } else {


### PR DESCRIPTION
Why

Pasting a screenshot didn't work properly if something else had already been copied and pasted to the editor.

How

This fixes that the latest clipboard item is being taken from the clipboard, not the first one. When taking a screenshot, a it is is always pushed to the last index of the clipboardData.items array, so that's where we should get it. 

Below is a screenshot of the debugger showing two copied strings already in the clipboardData.items and the latest screenshot is the last one in the array.

![screenshot 2019-02-07 at 14 47 13](https://user-images.githubusercontent.com/33698053/52412453-7cbbb880-2ae7-11e9-8005-0a07451ab445.png)
