### PR TITLE
Fix/rich text editor screenshot sync revert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-editor",
-  "version": "4.1.8",
+  "version": "4.1.9-0",
   "description": "Matematiikkaeditori-spike",
   "author": "",
   "homepage": "https://github.com/digabi/rich-text-editor",

--- a/public/rich-text-editor.css
+++ b/public/rich-text-editor.css
@@ -1,11 +1,11 @@
 .rich-text-editor-hidden { display: none; }
 
-.rich-text-editor img { display: none; }
-.rich-text-editor img[src*="/math.svg"] { display: inline; vertical-align: middle; margin: 4px; padding: 3px 10px; cursor: pointer; border: 1px solid transparent;}
+.rich-text-editor img[src*="/math.svg"] { vertical-align: middle; margin: 4px; padding: 3px 10px; cursor: pointer; border: 1px solid transparent;}
+.rich-text-editor img[src$="/math.svg?latex="],
+.rich-text-editor img[src=""] { display: none;}
 .rich-text-editor:focus img[src*="/math.svg"],
 .rich-text-editor.rich-text-focused img[src*="/math.svg"] {  background: #EDF9FF; border: 1px solid #E6F2F8; }
-.rich-text-editor img[src^="/screenshot"] { display: inline; margin: 4px; }
-.rich-text-editor.rich-text-focused img[src^="data:image/gif;base64,R0lGODlhEAAQAPQAAP///wAAAPDw8IqK"] { display: inline; }
+.rich-text-editor img[src^="/screenshot"] { margin: 4px; }
 .rich-text-editor:focus img[src^="/screenshot"],
 .rich-text-editor.rich-text-focused img[src^="/screenshot"] { box-shadow: 0 0 3px 1px rgba(0, 0, 0, .2); }
 .rich-text-editor .mq-math-mode .mq-root-block { white-space: normal; }


### PR DESCRIPTION
# Why

Hiding the img tags should not be the functionality of the editor. It should be the functionality of the app using the editor. This fix will enable using the screenshots again on the standalone version of the rich text editor.

# How

Reverted the commit https://github.com/digabi/rich-text-editor/commit/2a69c7b7482430ee227d5a3ad9eeffb6caab92a8

The functionality of the commit was moved to render-exam repo.