### PR TITLE
Don't clear the equation with ctrl-e when editing

### DIFF
--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -55,7 +55,7 @@ export const makeRichText = (answer, options, onValueChanged = () => {}) => {
             }
         })
         .on('keydown', e => {
-            if (u.isCtrlKey(e, keyCodes.E) && !$(e.target).hasClass('math-editor-latex-field')) {
+            if (u.isCtrlKey(e, keyCodes.E) && !focus.equationField && !focus.latexField) {
                 e.preventDefault()
                 math.insertNewEquation()
             }


### PR DESCRIPTION
There already was a fix for this.
For some reason the previous class condition of the fix was not met.
Now we have simpler condition which checks the element type is not textarea (currently editing the equation).