### PR TITLE
Compile code as ES modules

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "lib": ["dom", "es2017"],
-    "module": "commonjs",
+    "module": "es2015",
     "noEmit": false,
     "outDir": "../dist"
   }


### PR DESCRIPTION
This enables smaller bundles in downstream code.

1) The modules will not contain TypeScript emitted import helpers
2) Tree shaking might work better.