### PR TITLE
More functional and less disruptive relative url converter

### DIFF
--- a/src/sanitizeOpts.js
+++ b/src/sanitizeOpts.js
@@ -4,5 +4,6 @@ export const sanitizeOpts = {
         img: ['src', 'alt'],
     },
     allowedSchemes: ['data'],
+    allowedSchemesAppliedToAttributes: ['src'],
     exclusiveFilter: (frame) => frame.attribs['data-js'] === 'mathEditor',
 }

--- a/src/util.js
+++ b/src/util.js
@@ -8,7 +8,21 @@ const screenshotImageSelector =
     'img[src^="/screenshot/"], img[src^="data:image/png"], img[src^="data:image/gif"], img[src^="data:image/jpeg"]'
 export const invalidImageSelector = 'img:not(img[src^="data"], img[src^="/math.svg?latex="], img[src^="/screenshot/"])'
 function convertLinksToRelative(html) {
-    return html.replace(new RegExp(document.location.origin, 'g'), '')
+    const domParser = new DOMParser().parseFromString(html, 'text/html')
+    const elementList = domParser.getElementsByTagName('img')
+
+    for (let i = 0; i < elementList.length; i++) {
+        const element = elementList[i]
+        const src = element.getAttribute('src')
+        if (!src.startsWith('http')) continue
+        try {
+            let url = new URL(src)
+            element.setAttribute('src', url.href.replace(url.origin, ''))
+        } catch (e) {
+            continue
+        }
+    }
+    return domParser.body.innerHTML
 }
 
 function isBlockElement(node) {

--- a/src/util.js
+++ b/src/util.js
@@ -14,6 +14,7 @@ function convertLinksToRelative(html) {
     for (let i = 0; i < elementList.length; i++) {
         const element = elementList[i]
         const src = element.getAttribute('src')
+        if (!src) continue
         if (!src.startsWith('http')) continue
         try {
             let url = new URL(src)


### PR DESCRIPTION
Fixes #421 by specifically targetting src attributes on img tags and leaving user written content alone
Fixes #165 without requiring any extra configuration
Fixes dynamic-dynamic copying as described in #418 