### PR TITLE
Prevent scroll position drift when editing

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -73,11 +73,9 @@ function preventIfTrue(e, val) {
 export function sanitizeContent(answerElement) {
     const $answerElement = $(answerElement)
     const $mathEditor = $answerElement.find('[data-js="mathEditor"]')
-    const scrollPos = $(window).scrollTop()
     $mathEditor.hide()
     const text = $answerElement.get(0).innerText
     $mathEditor.show()
-    $(window).scrollTop(scrollPos)
 
     const html = sanitize($answerElement.html())
 


### PR DESCRIPTION
Window scroll position was unintentionally drifting when entering characters to
rich-text-editor with some browser and scaling settings.