### PR TITLE
Add option imagesToPreserve to keep wanted screenshots in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Rollup is probably needed.
 4. Run `yarn dev`.
 5. Go to [http://localhost:5000](http://localhost:5000)
 
+### Tests
+
+Go to [http://localhost:5000/test/tests.html](http://localhost:5000/test/tests.html)
+
 ## Example of direct usage
 
 Demo: http://digabi.github.io/rich-text-editor/

--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -29,7 +29,6 @@ const focus = state.focus
 export const makeRichText = (answer, options, onValueChanged = () => {}) => {
     const l = locales[options.locale || 'FI'].editor
 
-    const saver = options.screenshot.saver
     const baseUrl = options.baseUrl || ''
     const ignoreSaveObject = options.ignoreSaveObject || false
 
@@ -79,14 +78,14 @@ export const makeRichText = (answer, options, onValueChanged = () => {}) => {
             pasteInProgress = true
             setTimeout(() => {
                 $(e.target).html(u.sanitize(e.target.innerHTML))
-                clipboard.persistInlineImages($(e.currentTarget), saver)
+                clipboard.persistInlineImages($(e.currentTarget), options)
                 pasteInProgress = false
             }, 100)
         })
         .on('paste', (e) => {
             pasteInProgress = true
             setTimeout(() => (pasteInProgress = false), 0)
-            clipboard.onPaste(e, saver)
+            clipboard.onPaste(e, options)
         })
     setTimeout(() => document.execCommand('enableObjectResizing', false, false), 0)
 }

--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,10 @@ const emptyEquationSelector = 'img[src="/math.svg?latex="]'
 export const equationImageSelector = `img[src^="/math.svg?latex="]:not(${emptyEquationSelector}), img[src^="data:image/svg+xml"]`
 const screenshotImageSelector =
     'img[src^="/screenshot/"], img[src^="data:image/png"], img[src^="data:image/gif"], img[src^="data:image/jpeg"]'
-export const invalidImageSelector = 'img:not(img[src^="data"], img[src^="/math.svg?latex="], img[src^="/screenshot/"])'
+export const invalidImageSelector = (selectors) =>
+    `img:not(img[src^="data"], img[src^="/math.svg?latex="], img[src^="/screenshot/"], ${
+        selectors && selectors.map((selector) => `img[src^="${selector}"]`)
+    })`
 function convertLinksToRelative(html) {
     return html.replace(new RegExp(document.location.origin, 'g'), '')
 }


### PR DESCRIPTION
Adds imagesToPreserve option for makeRichText. Usage with array of strings, for example: imagesToPreserve: ['/files']
When user pastes text/html clipBoard automatically cleans unwanted images. With this option it is possible to keep screenshots uploaded to somewhere else when user pastes text/html. 

Also: I didn't understand how the development should work. Index.html is not updated when yarn dev is run as the editor bundle comes from cdn. Then using the testfile it was not mentioned in the readme so I added that information as well. Creating testcase for this option seemed quite tedious as well as the paste event seems to clear the whole HTML. 