### PR TITLE
Add undo and redo functionality to formula editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" type="text/css" href="//unpkg.com/rich-text-editor/dist/rich-text-editor.css"/>
   <script src="//code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/bacon.js/1.0.1/Bacon.min.js"></script>
-  <script src="//unpkg.com/rich-text-editor/dist/rich-text-editor-bundle.js"></script>
+  <script src="./dist/rich-text-editor-bundle.js"></script>
   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js">
   </script>
   <style>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:tsc": "tsc -p src",
     "build:assets": "bash -c 'mkdir -p dist; cp public/{rich-text-editor.css,*.svg} dist/'",
     "build": "concurrently --prefix \"[{name}]\" --names \"TSC,ASSETS\" \"npm run build:tsc\" \"npm run build:assets\"",
-    "build:bundle": "TYPECHECK=1 webpack --mode production --config webpack.bundle.config.js",
+    "build:bundle": "webpack --mode development --config webpack.bundle.config.js",
     "start": "node test/index.js",
     "test": "eslint . && test/testRunner.js",
     "dev": "supervisor -i public,test test/index.js",

--- a/src/util.js
+++ b/src/util.js
@@ -128,3 +128,8 @@ export function scrollIntoView($element) {
         $window.scrollTop(pos - windowHeight)
     }
 }
+
+Array.prototype.last = function() {
+    return this[this.length - 1];
+}
+

--- a/src/util.js
+++ b/src/util.js
@@ -129,7 +129,6 @@ export function scrollIntoView($element) {
     }
 }
 
-Array.prototype.last = function() {
-    return this[this.length - 1];
+export function last(array) {
+    return array[array.length - 1]
 }
-


### PR DESCRIPTION
I've added support for undoing and redoing inside the formula editor. 

It works as undo/redo conventionally does, save for the following issues:
- The cursor loses its position when undoing or redoing. There is no straightforward method for getting and setting the cursor's position in the MathQuill API, but I will continue looking into an implementation. It appears even the hugely popular MathQuill-powered graphing calculator Desmos suffers from the same issue.
- The undo and redo actions are only triggered by keydown events caused by the Ctrl+Z and Ctrl+Y keys respectively, so an 'undo' event such as one caused by the right-click context menu will not trigger the expected action. This is however such a minor issue that I see it as hardly worth fixing.

I don't have much experience in JavaScript or any formal training in programming, so I understand if this is for any reason unsuitable for merging. I would appreciate any feedback.

Would resolve #454.

Demonstration:
![undo](https://user-images.githubusercontent.com/22960424/154807901-7bfd8bab-a2ad-4f8d-8a4a-abef06d48662.gif)