### PR TITLE
Use currentTarget in drop event

### DIFF
--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -86,7 +86,7 @@ export const makeRichText = (answer, options, onValueChanged = () => {}) => {
         .on('drop', (e) => {
             pasteInProgress = true
             setTimeout(() => {
-                $(e.target).html(sanitize(e.target.innerHTML))
+                $(e.currentTarget).html(sanitize(e.currentTarget.innerHTML))
                 clipboard.persistInlineImages($(e.currentTarget), screenshotSaver, invalidImageSelector)
                 pasteInProgress = false
             }, 100)


### PR DESCRIPTION
When dropping elements (such as formula img's) the e.target may point to
child element img tag instead of the parent text-answer div. This caused
dragged element to disappear.