### PR TITLE
Fix/undo basic advanced commands

### DIFF
--- a/src/math-editor.js
+++ b/src/math-editor.js
@@ -121,14 +121,14 @@ export function init(
         if (undoRedo !== 0 && mqInstance.latex().length === 0 && latex.length > 0) {
             $latexField.focus()
         }
-        undoRedo = undoRedoCodes.NOCHANGE
+        setTimeout(() => (undoRedo = undoRedoCodes.NOCHANGE), 2)
     }
 
     function onMqEdit(e) {
         e && e.originalEvent && e.originalEvent.stopPropagation()
         clearTimeout(mqEditTimeout)
         mqEditTimeout = setTimeout(() => {
-            if (focus.latexField) return
+            if (focus.latexField || undoRedo !== undoRedoCodes.NOCHANGE) return
             const latex = mqInstance.latex()
             $latexField.val(latex)
             renderPossibleError()

--- a/src/toolbars.js
+++ b/src/toolbars.js
@@ -152,7 +152,7 @@ function initMathToolbar($mathToolbar, mathEditor) {
                 )
                 .join('')
         )
-        .on('mousedown', 'button', (e) => {
+        .on('mousedown', '.rich-text-editor-button-grid', (e) => {
             e.preventDefault()
             const dataset = e.currentTarget.dataset
             mathEditor.insertMath(dataset.command, dataset.latexcommand, dataset.usewrite === 'true')


### PR DESCRIPTION
Fixes #532 

Also fixes a problem with unwanted text getting inserted into MathQuill-field when focus is on LaTeX-field and undo or redo is done by clicking the button.