### PR TITLE
Fix parenthesized text misplacement in math-editor

### DIFF
--- a/public/rich-text-editor.css
+++ b/public/rich-text-editor.css
@@ -43,7 +43,7 @@
 }
 
 .rich-text-editor .mq-math-mode .mq-root-block {
-  white-space: normal;
+  white-space: nowrap;
 }
 
 .rich-text-editor:focus,


### PR DESCRIPTION
Fixes an issue where text last character of text inside braces (curly braces, parentheses, or square brackets) in the math editor was misplaced when the cursor was between the last character and the closing brace. Caused by `rich-text-editor.css`'s overwriting of a MathQuill `whitespace: nowrap;` CSS declaration.