### PR TITLE
Rerender equation svg on undo redo actions. Allows to save equation w…

### DIFF
--- a/src/math-editor.js
+++ b/src/math-editor.js
@@ -262,6 +262,7 @@ export function init(
         undoRedo = undoRedoCodes.UNDO
         redoStack.push(undoStack.pop())
         mqInstance.latex(u.last(undoStack))
+        updateMathImgWithDebounce($mathEditorContainer.prev(), mqInstance.latex())
         $latexField.val(u.last(undoStack))
         updateUndoRedoStacks()
         updateLatexFieldHeight()
@@ -273,6 +274,7 @@ export function init(
         undoRedo = undoRedoCodes.REDO
         mqInstance.latex(u.last(redoStack))
         $latexField.val(redoStack.pop())
+        updateMathImgWithDebounce($mathEditorContainer.prev(), mqInstance.latex())
         updateUndoRedoStacks()
         updateLatexFieldHeight()
         renderPossibleError()


### PR DESCRIPTION
Rerender equation svg on undo redo actions. Currently it happens only when blur/focusout occur on equation editor. Updating svg on undo&redo allows to save equation in proper state without calling blur/focustout first. 