### PR TITLE
Fix mathquill freezing after drag and drop in latexField

### DIFF
--- a/src/math-editor.js
+++ b/src/math-editor.js
@@ -93,7 +93,7 @@ export function init(
             onFocusChanged()
         })
         .on('keydown', onKeyDown)
-        .on('paste', (e) => e.stopPropagation())
+        .on('paste drop', (e) => e.stopPropagation())
 
     function onKeyDown(e) {
         if ($('.rich-text-editor-overlay').is(':visible')) return


### PR DESCRIPTION
Steps to reproduce issue:
- Type anything into an equation
- Select some text inside the raw latex field
- Move the selected text inside the raw latex field by dragging and dropping
- Equation editor can no longer be used until the page is reloaded

Text inside latexField is draggable at least on Chromium, but not on all browsers.