### PR TITLE
Add proper cleanup with new Jquery version.

### DIFF
--- a/test/tests.front.js
+++ b/test/tests.front.js
@@ -319,6 +319,9 @@ describe('rich text editor', () => {
         describe('equation click opens and esc closes math editor', () => {
             before(() => $el.answer1.blur())
             after(defaults)
+            after(u.delayFor(100))
+            after(() => $el.equationFieldTextArea.blur())
+            after(u.delayFor(100))
 
             it('editor is visible and then hidden', () => {
                 expect($el.answer1).to.not.have.class('rich-text-focused')


### PR DESCRIPTION
Jquery 3.7.0 changed it's focus functionality. It uses focusin event to support old IE. This broke test as focusin event came later in next test.

https://blog.jquery.com/2023/05/11/jquery-3-7-0-released-staying-in-order/