### PR TITLE
Add similar 100ms delay to paste event that is in drop event;

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-image-paste.1",
+  "version": "7.2.3-image-paste.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rich-text-editor",
-      "version": "7.2.3-image-paste.1",
+      "version": "7.2.3-image-paste.2",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/express": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.2",
+  "version": "7.2.3-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rich-text-editor",
-      "version": "7.2.2",
+      "version": "7.2.3-0",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/express": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-image-paste.3",
+  "version": "7.2.3-image-paste.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rich-text-editor",
-      "version": "7.2.3-image-paste.3",
+      "version": "7.2.3-image-paste.4",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/express": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-image-paste.2",
+  "version": "7.2.3-image-paste.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rich-text-editor",
-      "version": "7.2.3-image-paste.2",
+      "version": "7.2.3-image-paste.3",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/express": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-image-paste.0",
+  "version": "7.2.3-image-paste.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rich-text-editor",
-      "version": "7.2.3-image-paste.0",
+      "version": "7.2.3-image-paste.1",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/express": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-0",
+  "version": "7.2.3-image-paste.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rich-text-editor",
-      "version": "7.2.3-0",
+      "version": "7.2.3-image-paste.0",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/express": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-image-paste.2",
+  "version": "7.2.3-image-paste.3",
   "description": "Rich text editor",
   "author": "",
   "homepage": "https://github.com/digabi/rich-text-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.2",
+  "version": "7.2.3-0",
   "description": "Rich text editor",
   "author": "",
   "homepage": "https://github.com/digabi/rich-text-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-0",
+  "version": "7.2.3-image-paste.0",
   "description": "Rich text editor",
   "author": "",
   "homepage": "https://github.com/digabi/rich-text-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-image-paste.0",
+  "version": "7.2.3-image-paste.1",
   "description": "Rich text editor",
   "author": "",
   "homepage": "https://github.com/digabi/rich-text-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-image-paste.3",
+  "version": "7.2.3-image-paste.4",
   "description": "Rich text editor",
   "author": "",
   "homepage": "https://github.com/digabi/rich-text-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.3-image-paste.1",
+  "version": "7.2.3-image-paste.2",
   "description": "Rich text editor",
   "author": "",
   "homepage": "https://github.com/digabi/rich-text-editor",

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -4,26 +4,18 @@ import loadingImg from './loadingImg'
 export function onPaste(e, saver, invalidImageSelector, fileTypes, sanitize) {
     const clipboardData = e.originalEvent.clipboardData
 
-    console.log('clipboardData', clipboardData)
-
-    const types = Array.from(clipboardData.types)
-    console.log('clipboardData.types', types)
-
     const file =
         clipboardData.items &&
         clipboardData.items.length > 0 &&
         clipboardData.items[clipboardData.items.length - 1].getAsFile()
 
     const clipboardDataAsHtml = clipboardData.getData('text/html')
-    console.log('clipboardDataAsHtml', clipboardDataAsHtml)
 
     if (!file && (!clipboardDataAsHtml || !clipboardDataAsHtml.length)) {
-        console.log('PREVENTING')
+        // when copy pasting images from disk, in certain environments paste event is triggered before
+        // file is populated to clipboardData.items
         e.preventDefault()
-        return
-    }
-
-    if (file) {
+    } else if (file) {
         onPasteBlob(e, file, saver, fileTypes)
     } else {
         if (clipboardDataAsHtml)

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -6,9 +6,6 @@ export function onPaste(e, saver, invalidImageSelector, fileTypes, sanitize) {
 
     console.log('clipboardData', clipboardData)
 
-    const array = Array.from(clipboardData.files)
-    console.log('clipboardData.files', array)
-
     const types = Array.from(clipboardData.types)
     console.log('clipboardData.types', types)
 
@@ -17,12 +14,18 @@ export function onPaste(e, saver, invalidImageSelector, fileTypes, sanitize) {
         clipboardData.items.length > 0 &&
         clipboardData.items[clipboardData.items.length - 1].getAsFile()
 
-    console.log('file', file)
+    const clipboardDataAsHtml = clipboardData.getData('text/html')
+    console.log('clipboardDataAsHtml', clipboardDataAsHtml)
+
+    if (!file && (!clipboardDataAsHtml || !clipboardDataAsHtml.length)) {
+        console.log('PREVENTING')
+        e.preventDefault()
+        return
+    }
 
     if (file) {
         onPasteBlob(e, file, saver, fileTypes)
     } else {
-        const clipboardDataAsHtml = clipboardData.getData('text/html')
         if (clipboardDataAsHtml)
             onPasteHtml(e, $(e.currentTarget), clipboardDataAsHtml, saver, invalidImageSelector, fileTypes, sanitize)
         else onLegacyPasteImage($(e.currentTarget), saver, invalidImageSelector, fileTypes)

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -3,10 +3,19 @@ import loadingImg from './loadingImg'
 
 export function onPaste(e, saver, invalidImageSelector, fileTypes, sanitize) {
     const clipboardData = e.originalEvent.clipboardData
+
+    console.log('clipboardData', clipboardData)
+
+    const array = Array.from(clipboardData.files)
+    console.log('clipboardData.files', array)
+
     const file =
         clipboardData.items &&
         clipboardData.items.length > 0 &&
         clipboardData.items[clipboardData.items.length - 1].getAsFile()
+
+    console.log('file', file)
+
     if (file) {
         onPasteBlob(e, file, saver, fileTypes)
     } else {
@@ -65,6 +74,9 @@ function markAndGetInlineImagesAndRemoveForbiddenOnes($editor, invalidImageSelec
         .find('img[src^="data:image/"]')
         .toArray()
         .map((el) => ({ ...decodeBase64Image(el.getAttribute('src')), el }))
+
+    console.log('images', images)
+
     images.filter(isForbiddenInlineImage).forEach(({ el }) => el.remove())
     const pngImages = images.filter(({ type }) => fileTypes.includes(type))
     pngImages.forEach(({ el }) => el.setAttribute('src', loadingImg))

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -9,6 +9,9 @@ export function onPaste(e, saver, invalidImageSelector, fileTypes, sanitize) {
     const array = Array.from(clipboardData.files)
     console.log('clipboardData.files', array)
 
+    const types = Array.from(clipboardData.types)
+    console.log('clipboardData.types', types)
+
     const file =
         clipboardData.items &&
         clipboardData.items.length > 0 &&

--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -95,12 +95,6 @@ export const makeRichText = (answer, options, onValueChanged = () => {}) => {
             pasteInProgress = true
             setTimeout(() => (pasteInProgress = false), 0)
             clipboard.onPaste(e, screenshotSaver, invalidImageSelector, fileTypes, sanitize)
-
-            // pasteInProgress = true
-            // setTimeout(() => {
-            //     setTimeout(() => (pasteInProgress = false), 0)
-            //     clipboard.onPaste(e, screenshotSaver, invalidImageSelector, fileTypes, sanitize)
-            // }, 100)
         })
     setTimeout(() => document.execCommand('enableObjectResizing', false, false), 0)
 }

--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -93,10 +93,14 @@ export const makeRichText = (answer, options, onValueChanged = () => {}) => {
         })
         .on('paste', (e) => {
             pasteInProgress = true
-            setTimeout(() => {
-                setTimeout(() => (pasteInProgress = false), 0)
-                clipboard.onPaste(e, screenshotSaver, invalidImageSelector, fileTypes, sanitize)
-            }, 100)
+            setTimeout(() => (pasteInProgress = false), 0)
+            clipboard.onPaste(e, screenshotSaver, invalidImageSelector, fileTypes, sanitize)
+
+            // pasteInProgress = true
+            // setTimeout(() => {
+            //     setTimeout(() => (pasteInProgress = false), 0)
+            //     clipboard.onPaste(e, screenshotSaver, invalidImageSelector, fileTypes, sanitize)
+            // }, 100)
         })
     setTimeout(() => document.execCommand('enableObjectResizing', false, false), 0)
 }

--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -94,8 +94,8 @@ export const makeRichText = (answer, options, onValueChanged = () => {}) => {
         .on('paste', (e) => {
             pasteInProgress = true
             setTimeout(() => {
+                setTimeout(() => (pasteInProgress = false), 0)
                 clipboard.onPaste(e, screenshotSaver, invalidImageSelector, fileTypes, sanitize)
-                pasteInProgress = false
             }, 100)
         })
     setTimeout(() => document.execCommand('enableObjectResizing', false, false), 0)

--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -93,8 +93,10 @@ export const makeRichText = (answer, options, onValueChanged = () => {}) => {
         })
         .on('paste', (e) => {
             pasteInProgress = true
-            setTimeout(() => (pasteInProgress = false), 0)
-            clipboard.onPaste(e, screenshotSaver, invalidImageSelector, fileTypes, sanitize)
+            setTimeout(() => {
+                clipboard.onPaste(e, screenshotSaver, invalidImageSelector, fileTypes, sanitize)
+                pasteInProgress = false
+            }, 100)
         })
     setTimeout(() => document.execCommand('enableObjectResizing', false, false), 0)
 }

--- a/test/tests.front.js
+++ b/test/tests.front.js
@@ -157,6 +157,7 @@ describe('rich text editor', () => {
                 }
                 $el.answer1.trigger(u.pasteEventMock()).trigger('input')
             })
+            before(u.delayFor(150))
 
             it('ignores other than png images', () => {
                 expect($el.answer1.find('img').length).to.equal(currentImgAmout)
@@ -200,6 +201,7 @@ describe('rich text editor', () => {
                 }
                 $el.answer3.trigger(u.pasteEventMock()).trigger('input')
             })
+            before(u.delayFor(150))
 
             it('saves pasted image', () => {
                 expect($el.answer3.find('img:last'))
@@ -437,6 +439,7 @@ describe('rich text editor', () => {
                 )
                 .trigger('input')
         })
+        before(u.delayFor(150))
 
         it('inserts sanitized content', () => {
             expect(savedValues[1]).to.eql([
@@ -450,6 +453,7 @@ describe('rich text editor', () => {
     })
 
     describe('when trying to drag unsanitized content', () => {
+        before(clear)
         before('dropping banned tags', () => {
             $el.answer1.html('<div class="forbidden"><b>drop</b></div><div>bar</div><a href="/">link text</a> ')
             $el.answer1.trigger('drop')
@@ -460,11 +464,6 @@ describe('rich text editor', () => {
         it('drops sanitized content', () => {
             expect($el.answer1).to.have.html('drop<br>bar<br>link text ')
             expect(savedValues[0]).to.eql([
-                {
-                    answerHTML: 'drop<br />bar<br />link text',
-                    answerText: 'drop\nbar\nlink text',
-                    imageCount: 0,
-                },
                 {
                     answerHTML: 'drop<br />bar<br />link text',
                     answerText: 'drop\nbar\nlink text',


### PR DESCRIPTION
Without the delay, in some environments, it appeared that the onPaste() code was run too early, the image was not added to the DOM element, and thus it was not successfully removed if it was forbidden one (svg for example). Adding the delay fixes the problem, or at least now it works in similar way than drag drop.