### PR TITLE
Add delay to legacy image pasting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.2",
+  "version": "7.2.3-image-paste-debug.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rich-text-editor",
-      "version": "7.2.2",
+      "version": "7.2.3-image-paste-debug.1",
       "dependencies": {
         "@digabi/mathquill": "^0.10.12",
         "@types/express": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-text-editor",
-  "version": "7.2.2",
+  "version": "7.2.3-image-paste-debug.1",
   "description": "Rich text editor",
   "author": "",
   "homepage": "https://github.com/digabi/rich-text-editor",

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -39,10 +39,10 @@ function onPasteHtml(event, $answer, clipboardDataAsHtml, saver, invalidImageSel
 }
 
 function onLegacyPasteImage($editor, saver, invalidImageSelector, fileTypes) {
-    persistInlineImages($editor, saver, invalidImageSelector, fileTypes)
+    persistInlineImages($editor, saver, invalidImageSelector, fileTypes, 100)
 }
 
-export function persistInlineImages($editor, screenshotSaver, invalidImageSelector, fileTypes) {
+export function persistInlineImages($editor, screenshotSaver, invalidImageSelector, fileTypes, delay = 0) {
     setTimeout(
         () =>
             Promise.all(
@@ -55,7 +55,7 @@ export function persistInlineImages($editor, screenshotSaver, invalidImageSelect
                         }),
                 ),
             ).then(() => $editor.trigger('input')),
-        0,
+        delay,
     )
 }
 

--- a/test/tests.front.js
+++ b/test/tests.front.js
@@ -134,6 +134,7 @@ describe('rich text editor', () => {
                 }
                 $el.answer1.trigger(u.pasteEventMock()).trigger('input')
             })
+            before(u.delayFor(150))
 
             it('saves pasted image', () => {
                 expect($el.answer1.find('img:last'))
@@ -157,6 +158,7 @@ describe('rich text editor', () => {
                 }
                 $el.answer1.trigger(u.pasteEventMock()).trigger('input')
             })
+            before(u.delayFor(150))
 
             it('ignores other than png images', () => {
                 expect($el.answer1.find('img').length).to.equal(currentImgAmout)
@@ -200,6 +202,7 @@ describe('rich text editor', () => {
                 }
                 $el.answer3.trigger(u.pasteEventMock()).trigger('input')
             })
+            before(u.delayFor(150))
 
             it('saves pasted image', () => {
                 expect($el.answer3.find('img:last'))


### PR DESCRIPTION
In certain environments copy pasting image from desktop/file system may cause the on('paste') to be run too early, not containing the image in clipboard data. Add 100ms delay to legacy image pasting to patch those cases.