### PR TITLE
Mahdollista rich-text-editorin pakkoinitialisointi

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,18 @@
 export interface RichTextEditorOptions {
-  ignoreSaveObject?: boolean;
-  locale?: "FI" | "SV";
-  screenshotSaver?: ({ type, data, el }: { type: string; data: Buffer; el: Element }) => Promise<string>;
-  baseUrl?: string;
-  screenshotImageSelector?: string;
-  invalidImageSelector?: string;
-  fileTypes?: string[];
-  sanitize?: (markup: string) => string;
-  updateMathImg?: (jQuery: {}, latex: string) => void;
+  ignoreSaveObject?: boolean
+  locale?: 'FI' | 'SV'
+  screenshotSaver?: ({ type, data, el }: { type: string; data: Buffer; el: Element }) => Promise<string>
+  baseUrl?: string
+  screenshotImageSelector?: string
+  invalidImageSelector?: string
+  fileTypes?: string[]
+  sanitize?: (markup: string) => string
+  updateMathImg?: (jQuery: {}, latex: string) => void
+  forceInit?: boolean
 }
 
 export function makeRichText(
   element: Element,
   options: RichTextEditorOptions,
-  onChange: (data: { answerHTML: string; answerText: string }) => void
+  onChange: (data: { answerHTML: string; answerText: string }) => void,
 ): void

--- a/src/rich-text-editor.js
+++ b/src/rich-text-editor.js
@@ -37,14 +37,20 @@ export const makeRichText = (answer, options, onValueChanged = () => {}) => {
         invalidImageSelector,
         locale,
         updateMathImg,
+        forceInit,
     } = { ...u.defaults, ...options }
     const l = locales[locale].editor
-    if (state.firstCall) {
+    if (state.firstCall || forceInit) {
         state.firstCall = false
         state.math = mathEditor.init($outerPlaceholder, focus, baseUrl, updateMathImg, l)
         const containers = toolbars.init(state.math, () => focus.richText, l)
         state.$toolbar = containers.toolbar
         const $helpOverlay = containers.helpOverlay
+        if (forceInit) {
+            $('.rich-text-editor-overlay').remove()
+            $('.rich-text-editor-tools').remove()
+            $('.rich-text-editor-hidden').remove()
+        }
         $('body').append($outerPlaceholder, state.$toolbar, $helpOverlay)
     }
     let pasteInProgress = false

--- a/src/util.js
+++ b/src/util.js
@@ -13,6 +13,7 @@ export const defaults = {
     fileTypes: ['image/png', 'image/jpeg'],
     sanitize: defaultSanitize,
     updateMathImg: undefined,
+    forceInit: false,
 }
 
 const emptyEquationSelector = 'img[src="/math.svg?latex="]'


### PR DESCRIPTION
Jos kentät missä käytetään rich-text-editoria ilmestyy ruudulle eri aikaan, rich-text-editor ei osaa toimia niiden kaikkien kanssa. Pakkoinitialisointi laittaa sen toimimaan ainakin viimeisimpien kenttien kanssa.