### PR TITLE
Fix Chrome cursor positioning after backspace

### DIFF
--- a/playwright/editor.spec.tsx
+++ b/playwright/editor.spec.tsx
@@ -75,6 +75,19 @@ test.describe('Rich text editor', () => {
     })
     await assertEditorHTMLContent(editor, 'Hello')
     await assertEditorTextContent(editor, 'Hello')
+    await page.keyboard.press('Control+E')
+    await page.keyboard.type('x^2')
+    await page.keyboard.press('Escape')
+    await assertEditorHTMLContent(
+      editor,
+      'Hello&nbsp;<span class="math-editor-wrapper" id="math-editor-0" contenteditable="false" style="display: contents;"><img src="http://localhost:5111/math.svg?latex=x%5E2" data-math-svg="true" data-latex="x^2" alt="x^2"></span>&nbsp;',
+    )
+    // assertEditorTextContent doesn't work with nbsp whitespaces
+    expect(await editor.textContent()).toMatch(/Hello\s\s/)
+    await page.keyboard.press('Backspace')
+    await page.keyboard.press('Backspace')
+    await assertEditorHTMLContent(editor, 'Hello&nbsp;')
+    expect(await editor.textContent()).toMatch(/Hello\s/)
   })
 
   test('can input special characters from toolbar', async ({ page }) => {

--- a/src/app/utils/create-math-stub.ts
+++ b/src/app/utils/create-math-stub.ts
@@ -16,10 +16,11 @@ export const MATH_EDITOR_CLASS = 'math-editor-wrapper'
  */
 export function createMathStub(id: string | number, atSelection = false) {
   const stub = document.createElement('span')
+  // attribute order matters for playwright test. Chrome and Firefox give html content in different (alphabetic) orders
   stub.className = MATH_EDITOR_CLASS
   stub.id = `math-editor-${id}`
-  stub.style.display = 'contents'
   stub.contentEditable = 'false'
+  stub.style.display = 'contents'
 
   if (atSelection) {
     const selection = window.getSelection()


### PR DESCRIPTION
In chrome when deleting whitespace after math editor, the cursor didn't move left. Place it one step left in this case manually.