### PR TITLE
Fix onAnswerChange not accepting empty input

### DIFF
--- a/src/app/state/index.tsx
+++ b/src/app/state/index.tsx
@@ -284,7 +284,7 @@ export function EditorStateProvider({
      */
     const fn = () => {
       const content = mainTextAreaRef.current?.innerHTML
-      if (content) {
+      if (content !== undefined) {
         const answer = getAnswer(content)
         onValueChange(answer)
 


### PR DESCRIPTION
Usually the textarea value is at least a <br /> tag, but in a test case in exam engine it was sometimes just an empty string.

Since the text field should be emptyable (some browers force a line break in a textarea minimum content) we should also accept an empty string in onAnswerChange.