### PR TITLE
Fix onblur being called twice in Chrome

### DIFF
--- a/src/app/state/index.tsx
+++ b/src/app/state/index.tsx
@@ -166,7 +166,7 @@ export function EditorStateProvider({
       onAnswerChange(true, true)
 
       if (forceCursorPosition) {
-        setCursorAroundElement(stub, forceCursorPosition)
+        setCursorAroundElement(image, forceCursorPosition)
       }
       image.classList.remove('active')
 

--- a/src/app/state/index.tsx
+++ b/src/app/state/index.tsx
@@ -168,12 +168,11 @@ export function EditorStateProvider({
       if (forceCursorPosition) {
         setCursorAroundElement(image, forceCursorPosition)
       }
-      image.classList.remove('active')
 
       safeRemove(stub)
       if (!latex) {
         safeRemove(image)
-      }
+      } else image.classList.remove('active')
     }
 
     function onChange(latex: string) {

--- a/src/app/state/index.tsx
+++ b/src/app/state/index.tsx
@@ -136,6 +136,16 @@ export function EditorStateProvider({
 
   const t = { FI, SV }[language]
 
+  /* Sometimes blur events cause multiple onBlur calls (at least in Chrome). Removing elements can then
+   * cause uncaught errors, which require no actions to be taken.*/
+  function safeRemove(e?: HTMLElement) {
+    try {
+      e?.remove()
+    } catch (_) {
+      /* No action needed.*/
+    }
+  }
+
   function spawnMathEditor(stub: HTMLElement, image: HTMLImageElement, props?: Partial<MathEditorProps>) {
     // This is called both on the creation of the component and each time the equation is opened after that
     function onOpen(handle: MathEditorHandle) {
@@ -160,10 +170,9 @@ export function EditorStateProvider({
       }
       image.classList.remove('active')
 
-      const stubElement = stub
-      stubElement.remove()
+      safeRemove(stub)
       if (!latex) {
-        image.remove()
+        safeRemove(image)
       }
     }
 


### PR DESCRIPTION
When pressing enter in math editor field, onBlur was called twice: first in mathQuill onEnter, then the element onBlur. This didn't happen in Firefox.

The side effect was, that an error was thrown in state onblur function when it tried to remove the stub element. Preventing the second call also helped by not calling onChange twice with the same value when blurring happened with and Enter press.

This didn't happen when blurring in other ways.