### PR TITLE
Add validation for missing LaTeX in mathSvg requests

### DIFF
--- a/playwright/editor.spec.tsx
+++ b/playwright/editor.spec.tsx
@@ -150,6 +150,11 @@ test.describe('Rich text editor', () => {
     await expect(editor.locator('img')).not.toBeVisible()
   })
 
+  test('missing latex returns 400', async ({ page }) => {
+    const response = await page.request.get('http://localhost:5111/math.svg?%3Cspan%20class')
+    expect(response.status()).toBe(400)
+  })
+
   test('can paste equation SVG from clipboard', async ({ page }) => {
     const latex = '\\varepsilon=\\frac{Q_2}{Q_1-Q_2}=\\frac{1}{eta}-1'
     const url = new URL(

--- a/server/mathSvg.js
+++ b/server/mathSvg.js
@@ -38,6 +38,10 @@ mjAPI.start()
 function mathSvgResponse(req, res) {
   res.type('svg')
   const latex = req.query.latex
+  if (!latex) {
+    res.sendStatus(400)
+    return
+  }
   latexToSvg(latex, (svg) => res.send(svg))
 }
 


### PR DESCRIPTION
Return a 400 status code if the LaTeX query parameter is missing in mathSvg API requests. Added a test to ensure proper handling of this scenario. This prevents potential errors caused by invalid or incomplete requests.