### PR TITLE
Allow empty latex

### DIFF
--- a/playwright/editor.spec.tsx
+++ b/playwright/editor.spec.tsx
@@ -158,6 +158,11 @@ test.describe('Rich text editor', () => {
     await expect(editor.locator('img')).not.toBeVisible()
   })
 
+  test('empty latex returns 200', async ({ page }) => {
+    const response = await page.request.get('http://localhost:5111/math.svg?latex=')
+    expect(response.status()).toBe(200)
+  })
+
   test('missing latex returns 400', async ({ page }) => {
     const response = await page.request.get('http://localhost:5111/math.svg?%3Cspan%20class')
     expect(response.status()).toBe(400)

--- a/server/mathSvg.js
+++ b/server/mathSvg.js
@@ -38,7 +38,7 @@ mjAPI.start()
 function mathSvgResponse(req, res) {
   res.type('svg')
   const latex = req.query.latex
-  if (!latex) {
+  if (latex === undefined) {
     res.sendStatus(400)
     return
   }


### PR DESCRIPTION
Return 200 with empty latex. Missing latex field returns 400.