### PR TITLE
WIP: Add equations with execCommand

### DIFF
--- a/playwright/test-utils.ts
+++ b/playwright/test-utils.ts
@@ -169,3 +169,13 @@ export const specialCharacters = {
 
 export const getLatexImgTag = (latex: string) =>
   `<img src="http://localhost:5111/math.svg?latex=${encodeURIComponent(latex)}" alt="${latex}">`
+
+export const undo = async (page: Page) => {
+  process.platform === 'darwin' ? await page.keyboard.press('Meta+z') : await page.keyboard.press('Control+z')
+}
+
+export const redo = async (page: Page) => {
+  process.platform === 'darwin'
+    ? await page.keyboard.press('Meta+Shift+z')
+    : await page.keyboard.press('Control+Shift+z')
+}

--- a/src/app/state/dom-helpers.tsx
+++ b/src/app/state/dom-helpers.tsx
@@ -1,0 +1,37 @@
+export const deleteElement = (element: HTMLElement) => {
+  if (!element) return
+  const range = document.createRange()
+  range.selectNode(element)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+  document.execCommand('delete')
+}
+export const replaceElement = (addToHistory: boolean, oldElement: HTMLElement, newElement: HTMLElement) => {
+  const range = document.createRange()
+  range.selectNode(oldElement)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+  if (addToHistory) {
+    document.execCommand('insertHTML', false, newElement.outerHTML)
+  } else {
+    range.deleteContents()
+    range.insertNode(newElement)
+  }
+}
+export const refreshElement = (element: HTMLElement) => {
+  if (!element) return
+  replaceElement(true, element, element)
+}
+
+export const insertAfter = (element: Element, newHtml: string) => {
+  console.debug('insertAfter', element, newHtml)
+  const range = document.createRange()
+  range.selectNode(element)
+  range.collapse(false)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+  document.execCommand('insertHTML', false, newHtml)
+}

--- a/src/app/utils/create-math-stub.ts
+++ b/src/app/utils/create-math-stub.ts
@@ -1,9 +1,6 @@
 export const MATH_EDITOR_CLASS = 'math-editor-wrapper'
 
 /**
- * Creates a new `HTMLSpanElement` that can be initialised into a new {@link MathEditor}.
- * The element will have the `MATH_EDITOR_CLASS` class name.
- *
  * By default the created `HTMLSpanElement` is *not* attached to the DOM. It is the
  * caller's responsibility to actually mount the element to the document. *However*,
  * if the `atSelection` argument is set to `true`, the box **will** be placed at the
@@ -26,7 +23,8 @@ export function createMathStub(id: string | number, atSelection = false, img?: E
     const range = selection.getRangeAt(0)
     range.deleteContents()
     range.insertNode(stub)
-    if (img) range.insertNode(img)
+    range.collapse(true)
+    if (img) document.execCommand('insertHTML', false, img.outerHTML)
 
     // If the new equation would be created inside another equations wrapper, move it outside of it
     const parent = stub.parentNode as Element


### PR DESCRIPTION
This would make it possible to use the browser's native undo history instead of having to craft one ourselves. This is not ready yet though, it's a bit buggy (for example, creating new equations on enter press in another equation doesn't quite work properly right now)