### PR TITLE
Preserve line break when a block element follows inline content

### DIFF
--- a/playwright/editor.spec.tsx
+++ b/playwright/editor.spec.tsx
@@ -324,6 +324,18 @@ test.describe('Rich text editor', () => {
     })
   })
 
+  // The browser sometimes wraps a new line in a <div> in contenteditable
+  // (e.g. when pressing Enter between images). The line break must survive
+  // sanitization even when the previous sibling is an image.
+  test('preserves line break when a div follows an image', async ({ page }) => {
+    const img = `<img src="data:image/png;base64,${samplePNG}" alt="">`
+    await setClipboardHTML(page, `${img}<div>${img}</div>`)
+    await paste(page)
+    await assertAnswer({
+      answerHtml: `${img}<br>${img}`,
+    })
+  })
+
   test('preserves tabs in pasted html', async ({ page }) => {
     const TAB = `${nbsp}${nbsp}${nbsp}${nbsp}`
     const htmlTab = '&nbsp;&nbsp;&nbsp;&nbsp;'

--- a/src/app/utils/sanitization.ts
+++ b/src/app/utils/sanitization.ts
@@ -58,16 +58,13 @@ function stripBlockElements(html: string) {
   parent.innerHTML = html.trim()
 
   do {
-    let lastNode: Node | undefined = undefined
     for (let i = 0; i < parent.childNodes.length; i++) {
       const node = parent.childNodes[i]
       if (isBlockElement(node)) {
-        // if the last node is a text node or a span, which is not empty, add a br before this node
-        if (
-          lastNode !== undefined &&
-          (lastNode.nodeType === Node.TEXT_NODE || lastNode.nodeName === 'SPAN') &&
-          /\S/.test(lastNode.textContent ?? '')
-        ) {
+        // Preserve the line break that the block element represents by inserting a <br>
+        // before it, unless the previous sibling already provides one (or there is no
+        // content before it that needs separating).
+        if (needsBrBeforeBlock(node.previousSibling)) {
           parent.insertBefore(document.createElement('br'), node)
         }
         // if this node has a last child that is not a br, add a br
@@ -79,11 +76,25 @@ function stripBlockElements(html: string) {
         }
         parent.removeChild(node)
       }
-      lastNode = node
     }
   } while (Array.prototype.some.call(parent.childNodes, (node: Node) => isBlockElement(node)))
 
   return parent.innerHTML
+}
+
+function needsBrBeforeBlock(prevSibling: Node | null) {
+  if (prevSibling === null) return false
+  if (prevSibling.nodeName === 'BR') return false
+  // A preceding block will be unwrapped and contribute its own trailing <br>
+  if (isBlockElement(prevSibling)) return false
+  // Whitespace-only text nodes and spans don't represent content that needs a line break
+  if (
+    (prevSibling.nodeType === Node.TEXT_NODE || prevSibling.nodeName === 'SPAN') &&
+    !/\S/.test(prevSibling.textContent ?? '')
+  ) {
+    return false
+  }
+  return true
 }
 
 function preserveTabs(html: string) {


### PR DESCRIPTION
**Bugi**
Kahden kuvan (tai kaavan) välissä oleva rivinvaihto ei säily sivun uudelleenlatauksen yli, eikä myöskään copy-pastessa. 

**Selitys**
Funktio `stripBlockElements` lisää `<br>`-tagin block-elementin (esim.` <div>`) eteen **vain jos** edellinen sisarus on text/span. Jos taas edellinen sisarus on `<img>`, niin `<br>` jää lisäämättä. Tämä johti rivinvaihdon katoamiseen, kun selain käärii rivin `<div>`:iin contenteditable-tilassa.

**Korjaus**
Lisätään `<br>` myös kun edellinen sisarus on `<img>`:
  - Tarkistus käyttää nyt node.previousSibling:iä (todellinen edellinen sisarus), ei aiempaa iteroitua solmua
  - Apufunktio needsBrBeforeBlock lisää `<br>`:n jos edellinen sisarus on merkityksellinen inline-sisältö — ei kuitenkaan jos se on jo `<br>`, toinen blokki (saa oman päättävän `<br>`:n purkaessa) tai pelkkää whitespacea

Vastauskenttä ennen sivunlatausta tai ennen copya:
<img width="243" height="448" alt="image" src="https://github.com/user-attachments/assets/abc90002-7133-49d4-b984-115851e1e8cb" />

Vastauskenttä sivunlatauksen tai pasten jälkeen: 
<img width="404" height="239" alt="image" src="https://github.com/user-attachments/assets/2a0f49bb-0a03-4472-bc4e-31d779d22562" />
