### PR TITLE
Keep the answer history debounce stable across re-renders

### DIFF
--- a/playwright/EditorInRerenderingParent.tsx
+++ b/playwright/EditorInRerenderingParent.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import RichTextEditor from '../src/app'
+import { Answer } from '../src/app/utility'
+
+/** Mimics a library user that stores the answer in state, and therefore re-renders the
+ * editor on every `onValueChange`. The exam engine does this by dispatching each change
+ * to a redux store, and that used to reset the answer history debounce on every keystroke.
+ * */
+export default function EditorInRerenderingParent() {
+  const [, setAnswer] = useState<Answer | null>(null)
+
+  return (
+    <RichTextEditor
+      language="FI"
+      baseUrl="http://localhost:5111"
+      onValueChange={setAnswer}
+      allowedFileTypes={['image/png', 'image/jpeg']}
+      initialValue=""
+      textAreaProps={{ editorStyle: { marginTop: '300px', minHeight: '200px' } }}
+    />
+  )
+}

--- a/playwright/editor.spec.tsx
+++ b/playwright/editor.spec.tsx
@@ -27,6 +27,7 @@ import {
   getLatexImgTag,
 } from './test-utils'
 import RichTextEditor from '../src/app'
+import EditorInRerenderingParent from './EditorInRerenderingParent'
 import { Answer } from '../src/app/utility'
 import fi from '../src/FI'
 import { BASIC, ALGEBRA, GEOMETRY, SET_THEORY } from '../src/app/components/toolbar/math-char-data'
@@ -758,6 +759,29 @@ test.describe('Rich text editor', () => {
         await page.keyboard.type(' (5)')
         await assertAnswer({ answerText: 'This (5) is a (1) (2) test\nThis is a second line' })
       })
+    })
+
+    test('moves one edit at a time even when the parent re-renders on every change', async ({ page, mount }) => {
+      await unmountComponent()
+      await mount(<EditorInRerenderingParent />)
+      const editor = getEditorLocator(page)
+      await editor.click()
+
+      await writeAndWaitForTimeout(page, 'aa')
+      await writeAndWaitForTimeout(page, 'bb')
+      await expect(editor).toHaveText('aabb')
+
+      await page.keyboard.press('Control+z')
+      await expect(editor).toHaveText('aa')
+
+      await page.keyboard.press('Control+z')
+      await expect(editor).toHaveText('')
+
+      await page.keyboard.press('Control+y')
+      await expect(editor).toHaveText('aa')
+
+      await page.keyboard.press('Control+y')
+      await expect(editor).toHaveText('aabb')
     })
   })
 

--- a/src/app/state/index.tsx
+++ b/src/app/state/index.tsx
@@ -339,10 +339,27 @@ export function EditorStateProvider({
     }
   }
 
-  const updateAnswerHistoryDebounced = debounceAnswerSave(
-    (content: string, caretPositionBefore: CaretPosition) => updateAnswerHistory(content, caretPositionBefore),
-    500,
-  )
+  /** `debounceAnswerSave` keeps its pending timer in a closure, so the debounced function has to
+   * survive re-renders. If it were recreated on every render, each call would get a timer of its own
+   * and none of them would ever be cancelled, making every single keystroke its own history entry.
+   * Library users who re-render the editor on `onValueChange` (e.g. by storing the answer in a
+   * store) would then undo and redo one character at a time instead of one edit at a time.
+   *
+   * The debounced callback reads `updateAnswerHistory` from a ref so that it always runs the
+   * current render's version instead of the one captured when the debounce was created.
+   * */
+  const updateAnswerHistoryRef = useRef(updateAnswerHistory)
+  updateAnswerHistoryRef.current = updateAnswerHistory
+
+  const updateAnswerHistoryDebouncedRef = useRef<ReturnType<typeof debounceAnswerSave>>()
+  if (!updateAnswerHistoryDebouncedRef.current) {
+    updateAnswerHistoryDebouncedRef.current = debounceAnswerSave(
+      (content: string, caretPositionBefore: CaretPosition) =>
+        updateAnswerHistoryRef.current(content, caretPositionBefore),
+      500,
+    )
+  }
+  const updateAnswerHistoryDebounced = updateAnswerHistoryDebouncedRef.current
 
   /**
    * @param shouldUpdateHistory - Whether to update the answer history (defaults to true)


### PR DESCRIPTION
**BUGI: exam-enginessä pitkän tekstivastauksen undo/redo peruu/palauttaa yhden merkin kerrallaan eikä kunnioita RTE:n luomaa vastaushistoriaa**

**Ongelma:** vastaushistorian debounce luotiin uudelleen jokaisella renderöinnillä, jolloin `clearTimeout` ei perunut edellistä ajastinta vaan jokainen kutsu kirjoitti oman historiamerkintänsä.

Tässä repossa provider ei renderöidy uudelleen kirjoittaessa, joten vika ei näy. Koejärjestelmässä jokainen muutos menee redux-storeen ja renderöi editorin uudelleen — silloin jokaisesta merkistä tuli oma historiamerkintänsä ja undo/redo liikkui merkki kerrallaan yhden muokkauksen sijaan.

**Korjaus:** debouncattu funktio pidetään refissä, jotta se säilyy renderöintien yli, ja `updateAnswerHistory` luetaan refistä, jotta pysyvä sulkeuma ajaa aina tuoreimman version.

Playwright-testi kattaa tapauksen, jossa vanhempi renderöityy uudelleen jokaisesta muutoksesta.
